### PR TITLE
Updated docs to allow eventual BibTeX citations for the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,21 @@ We are a couple friends passionate about ML.
 
 ## License
 Apache
+
+## Citing Elegy
+
+To cite this project:
+
+**BibTeX**
+
+```
+@software{elegy2020repository,
+author = {PoetsAI},
+title = {Elegy: A Keras-like deep learning framework based on Jax & Haiku},
+url = {https://github.com/poets-ai/elegy},
+version = {0.1.3},
+year = {2020},
+}
+```
+
+Where the current *version* may be retrieved either from the `Release` tag or the file [elegy/\_\_init\_\_.py](https://github.com/poets-ai/elegy/blob/master/elegy/__init__.py) and the *year* corresponds to the project's release year.

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,3 +102,21 @@ We are a couple friends passionate about ML.
 
 ## License
 Apache
+
+## Citing Elegy
+
+To cite this project:
+
+**BibTeX**
+
+```
+@software{elegy2020repository,
+author = {PoetsAI},
+title = {Elegy: A Keras-like deep learning framework based on Jax & Haiku},
+url = {https://github.com/poets-ai/elegy},
+version = {0.1.3},
+year = {2020},
+}
+```
+
+Where the current *version* may be retrieved either from the `Release` tag or the file [elegy/\_\_init\_\_.py](https://github.com/poets-ai/elegy/blob/master/elegy/__init__.py) and the *year* corresponds to the project's release year.


### PR DESCRIPTION
**Motivation**
Since Jax + Haiku are being mostly used for research and exploration purposes, Elegy might play an important role for these tasks. Thereby, this short enhancement enables academic citation for its users, and may account for a wider visibility of the framework. 

**Updates**

- Defined a provisional _BibTeX_ citation schema
- Modified `README.md` at the bottom of the file
- Modified `docs/index.md` at the bottom of the file