### PR TITLE
Examples Cleanup

### DIFF
--- a/elegy/model/model.py
+++ b/elegy/model/model.py
@@ -705,7 +705,7 @@ class Model(ModelBase):
             the model later.
         - The model parameters + states serialized into HDF5 as `{path}/parameters.h5`.
         - The states of the optimizer serialized with `pickle` as
-            as `{path}/optimizer_state.pkl`, allowing to resume training
+            as `{path}/optimizer_parameters.pkl`, allowing to resume training
             exactly where you left off. We hope to use HDF5 in the future
             but `optax` states is incompatible with `deepdish`.
 
@@ -732,6 +732,24 @@ class Model(ModelBase):
 
         path.mkdir(parents=True, exist_ok=True)
 
+        parameters = self.get_parameters()
+
+        if "optimizer" in parameters:
+            del parameters["optimizer"]
+
+        deepdish.io.save(path / "parameters.h5", parameters)
+
+        # optimizer parameters saved as a pickle because optax uses named tuples
+        # which are converted to regular tuples by deepdish when loading.
+        if include_optimizer and self.optimizer is not None:
+            optimizer_params = self.optimizer.get_parameters()
+            with open(path / "optimizer_parameters.pkl", "wb") as f:
+                pickle.dump(optimizer_params, f)
+        else:
+            optimizer_params = None
+
+        self.reset()
+
         try:
             path = path / "model.pkl"
             with open(path, "wb") as f:
@@ -739,9 +757,12 @@ class Model(ModelBase):
         except BaseException as e:
             print(f"Error occurred saving the model object at {path}\nContinuing....")
 
-        # self.full_state = original_state
+        if optimizer_params is not None:
+            parameters["optimizer"] = optimizer_params
 
-    def load(self, path: tp.Union[str, Path]) -> None:
+        self.set_parameters(parameters)
+
+    def load(self, path: tp.Union[str, Path], include_optimizer: bool = True) -> None:
         """
         Loads all weights + states from a folder structure.
 
@@ -752,15 +773,23 @@ class Model(ModelBase):
 
         Arguments:
             path: path to a saved model's directory.
+            include_optimizer: If True, loads optimizer's state if available.
         """
         if isinstance(path, str):
             path = Path(path)
 
-        model = load(path)
-        self.set_parameters(model.get_parameters())
+        parameters: tp.Dict = deepdish.io.load(path / "parameters.h5")
+
+        optimizer_params_path = path / "optimizer_parameters.pkl"
+
+        if include_optimizer and optimizer_params_path.exists():
+            with open(optimizer_params_path, "rb") as f:
+                parameters["optimizer"] = pickle.load(f)
+
+        self.set_parameters(parameters)
 
 
-def load(path: tp.Union[str, Path]) -> Model:
+def load(path: tp.Union[str, Path], include_optimizer: bool = True) -> Model:
     """
     Loads a model from disk.
 
@@ -782,6 +811,7 @@ def load(path: tp.Union[str, Path]) -> Model:
 
     Arguments:
         path: path to a saved model's directory.
+        include_optimizer: If True, loads optimizer's state if available.
 
     Raises:
         OSError: in case the model was not found or could not be
@@ -795,5 +825,7 @@ def load(path: tp.Union[str, Path]) -> Model:
             model: Model = pickle.load(f)
         except BaseException as e:
             raise OSError(f"Could not load the model. Got exception: {e}")
+
+    model.load(path, include_optimizer=include_optimizer)
 
     return model

--- a/examples/imagenet/README.md
+++ b/examples/imagenet/README.md
@@ -1,7 +1,9 @@
 ## Training ResNet on ImageNet
 
 Adapted from the [Flax](https://github.com/google/flax) library.
+
 This example currently runs only on one device.
+
 See `requirements.txt` for required packages, additional to Elegy.
 
 ***
@@ -40,4 +42,5 @@ Pretrained models can be loaded with `elegy.model.load('path/to/model/')`
 
 ***
 [1] He, Kaiming, et al. "Deep residual learning for image recognition." Proceedings of the IEEE conference on computer vision and pattern recognition. 2016.
+
 [2] Russakovsky, Olga, et al. "Imagenet large scale visual recognition challenge." International journal of computer vision 115.3 (2015): 211-252.

--- a/examples/imagenet/README.md
+++ b/examples/imagenet/README.md
@@ -1,0 +1,43 @@
+## Training ResNet on ImageNet
+
+Adapted from the [Flax](https://github.com/google/flax) library.
+This example currently runs only on one device.
+See `requirements.txt` for required packages, additional to Elegy.
+
+***
+### Usage
+```
+resnet_imagenet.py --model=<ResNetXX> --output_dir=<./output/path> [flags]
+
+
+flags:
+  --model: <ResNet18|ResNet34|ResNet50|ResNet101|ResNet152|ResNet200>: Type of ResNet to train
+  --output_dir: Directory to save model checkpoints and tensorboard log data
+
+  --base_lr:      SGD optimizer base learning rate (default: '0.1')
+  --batch_size:   Input batch size (default: '64')
+  --[no]cache:    Whether to cache the data in RAM (default: 'false')
+  --dataset:      TFDS dataset name and version (default: 'imagenet2012:*.*.*')
+  --dtype: <float16|float32>: Mixed precision or normal mode (default: 'float32')
+  --epochs:       Number of epochs to train (default: '90')
+  --image_size:   Image size in pixels (default: '224')
+  --L2_reg:       L2 weight regularization (default: '0.0001')
+  --loss_scale:   Loss scale for numerical stability when dtype=float16 (default: '1.0')
+  --momentum:     SGD optimizer momentum (default: '0.9')
+  --[no]nesterov: SGD optimizer Nesterov mode (default: 'true')
+```
+
+***
+### Pretrained Models
+
+| Model    | Top-1 accuracy | Download |
+| ---      | ---            | ---      |
+| ResNet18 | 68.7%          | [model.pkl](https://www.dropbox.com/s/horba2lsjh2dwum/model.pkl?dl=1) |
+| ResNet50 | 76.5%          | [model.pkl](https://www.dropbox.com/s/g2mqsjxriq42q06/model.pkl?dl=1) |
+
+Pretrained models can be loaded with `elegy.model.load('path/to/model/')`
+
+
+***
+[1] He, Kaiming, et al. "Deep residual learning for image recognition." Proceedings of the IEEE conference on computer vision and pattern recognition. 2016.
+[2] Russakovsky, Olga, et al. "Imagenet large scale visual recognition challenge." International journal of computer vision 115.3 (2015): 211-252.

--- a/examples/imagenet/resnet_imagenet.py
+++ b/examples/imagenet/resnet_imagenet.py
@@ -1,23 +1,4 @@
-# PARAMETERS
-MODEL = "ResNet50"
-OUTPUT_DIRECTORY = "models/resnet50"
-EPOCHS = 90
-BATCH_SIZE = 64
-IMAGE_SIZE = 224  # image size in pixels
-DATASET = "imagenet2012:5.0.*"  # TFDS dataset name and version
-DTYPE = "float16"  # float16 for mixed_precision or float32 for normal mode
-LEARNING_RATE = 0.1 * BATCH_SIZE / 256.0
-MOMENTUM = 0.9
-NESTEROV = True
-L2_REGULARIZATION = 1e-4
-CACHE = False  # faster if True, but requires lots of RAM
-LOSS_SCALE = (
-    256.0 if DTYPE == "float16" else 1.0
-)  # for numerical stability when DTYPE is float16
-
-
 import os
-
 if "miniconda3/envs" in os.__file__:
     # specify the cuda location for XLA when working with conda environments
     os.environ["XLA_FLAGS"] = "--xla_gpu_cuda_data_dir=" + os.sep.join(
@@ -25,10 +6,12 @@ if "miniconda3/envs" in os.__file__:
     )
 
 
+from absl import flags, app
+
+
+import jax, jax.numpy as jnp
 # importing tensorflow_datasets before performing any jax convolutions gives me a 'DNN Library not found' error later
 # workaround: do a dummy convolution before importing tfds
-import jax, jax.numpy as jnp
-
 _x0 = jnp.zeros((1, 1, 1, 1))
 _x1 = jnp.zeros((1, 1, 1, 1))
 jax.lax.conv(_x0, _x1, (1, 1), "SAME").block_until_ready()
@@ -43,87 +26,121 @@ print("JAX version:", jax.__version__)
 print("Elegy version:", elegy.__version__)
 
 
-assert (
-    getattr(elegy.nets.resnet, MODEL, None) is not None
-), f"{MODEL} is not defined in elegy.nets.resnet"
-
-assert not os.path.exists(
-    OUTPUT_DIRECTORY
-), "Output directory already exists. Delete manually or specify a new one."
-os.makedirs(OUTPUT_DIRECTORY)
 
 
-# dataset
-dataset_builder = tfds.builder(DATASET)
-ds_train = input_pipeline.create_split(
-    dataset_builder,
-    batch_size=BATCH_SIZE,
-    image_size=IMAGE_SIZE,
-    dtype=DTYPE,
-    train=True,
-    cache=CACHE,
-)
-ds_valid = input_pipeline.create_split(
-    dataset_builder,
-    batch_size=BATCH_SIZE,
-    image_size=IMAGE_SIZE,
-    dtype=DTYPE,
-    train=False,
-    cache=CACHE,
-)
-N_BATCHES_TRAIN = dataset_builder.info.splits["train"].num_examples // BATCH_SIZE
-N_BATCHES_VALID = dataset_builder.info.splits["validation"].num_examples // BATCH_SIZE
+FLAGS = flags.FLAGS
 
-# generator that converts tfds dataset batches to jax arrays
-def tfds2jax_generator(tf_ds):
-    for batch in tf_ds:
-        yield jnp.asarray(batch["image"], dtype=DTYPE), jax.device_put(
-            jnp.asarray(batch["label"])
+flags.DEFINE_enum('model',      default=None,
+                     enum_values=['ResNet18', 'ResNet34', 'ResNet50', 'ResNet101', 'ResNet152', 'ResNet200'], 
+                     help='Type of ResNet to train')
+
+flags.DEFINE_string('output_dir', default=None, help='Directory to save model checkpoints and tensorboard log data')
+flags.DEFINE_integer('epochs', default=90, help='Number of epochs to train')
+flags.DEFINE_integer('batch_size', default=64, help='Input batch size')
+flags.DEFINE_integer('image_size', default=224, help='Image size in pixels')
+flags.DEFINE_string('dataset', default='imagenet2012:*.*.*', help='TFDS dataset name and version')
+flags.DEFINE_enum('dtype', default='float32', enum_values=['float16', 'float32'], help='Mixed precision or normal mode')
+flags.DEFINE_float('base_lr', default=0.1, help='SGD optimizer base learning rate')
+flags.DEFINE_float('momentum', default=0.9, help='SGD optimizer momentum')
+flags.DEFINE_bool('nesterov', default=True, help='SGD optimizer Nesterov mode')
+flags.DEFINE_float('L2_reg', default=1e-4, help='L2 weight regularization')
+flags.DEFINE_bool('cache', default=False, help='Whether to cache the data in RAM')
+flags.DEFINE_float('loss_scale', default=1.0, help='Loss scale for numerical stability when dtype=float16')
+
+flags.mark_flag_as_required('model')
+flags.mark_flag_as_required('output_dir')
+
+
+
+def main(argv):
+    assert len(argv)==1, 'Please specify arguments via flags. Use --help for instructions'
+
+    assert (
+        getattr(elegy.nets.resnet, FLAGS.model, None) is not None
+    ), f"{FLAGS.model} is not defined in elegy.nets.resnet"
+
+    assert not os.path.exists(
+        FLAGS.output_dir
+    ), "Output directory already exists. Delete manually or specify a new one."
+    os.makedirs(FLAGS.output_dir)
+
+
+    # dataset
+    dataset_builder = tfds.builder(FLAGS.dataset)
+    ds_train = input_pipeline.create_split(
+        dataset_builder,
+        batch_size=FLAGS.batch_size,
+        image_size=FLAGS.image_size,
+        dtype=FLAGS.dtype,
+        train=True,
+        cache=FLAGS.cache,
+    )
+    ds_valid = input_pipeline.create_split(
+        dataset_builder,
+        batch_size=FLAGS.batch_size,
+        image_size=FLAGS.image_size,
+        dtype=FLAGS.dtype,
+        train=False,
+        cache=FLAGS.cache,
+    )
+    N_BATCHES_TRAIN = dataset_builder.info.splits["train"].num_examples // FLAGS.batch_size
+    N_BATCHES_VALID = dataset_builder.info.splits["validation"].num_examples // FLAGS.batch_size
+
+    # generator that converts tfds dataset batches to jax arrays
+    def tfds2jax_generator(tf_ds):
+        for batch in tf_ds:
+            yield jnp.asarray(batch["image"], dtype=FLAGS.dtype), jax.device_put(
+                jnp.asarray(batch["label"])
+            )
+
+
+    # model and optimizer definition
+    def build_optimizer(lr, momentum, steps_per_epoch, n_epochs, nesterov, warmup_epochs=5):
+        cosine_schedule = optax.cosine_decay_schedule(
+            1, decay_steps=n_epochs * steps_per_epoch, alpha=1e-10
         )
+        warmup_schedule = optax.polynomial_schedule(
+            init_value=0.0,
+            end_value=1.0,
+            power=1,
+            transition_steps=warmup_epochs * steps_per_epoch,
+        )
+        schedule = lambda x: jnp.minimum(cosine_schedule(x), warmup_schedule(x))
+        optimizer = optax.sgd(lr, momentum, nesterov=nesterov)
+        optimizer = optax.chain(optimizer, optax.scale_by_schedule(schedule))
+        return optimizer
 
 
-# model and optimizer definition
-def build_optimizer(lr, momentum, steps_per_epoch, n_epochs, warmup_epochs=5):
-    cosine_schedule = optax.cosine_decay_schedule(
-        1, decay_steps=n_epochs * steps_per_epoch, alpha=1e-10
+    module = getattr(elegy.nets.resnet, FLAGS.model)(dtype=FLAGS.dtype)
+    model = elegy.Model(
+        module,
+        loss=[
+            elegy.losses.SparseCategoricalCrossentropy(from_logits=True, weight=FLAGS.loss_scale),
+            elegy.regularizers.GlobalL2(FLAGS.L2_reg / 2 * FLAGS.loss_scale),
+        ],
+        metrics=elegy.metrics.SparseCategoricalAccuracy(),
+        optimizer=build_optimizer(
+            FLAGS.base_lr / FLAGS.loss_scale, FLAGS.momentum, N_BATCHES_TRAIN, FLAGS.epochs, FLAGS.nesterov
+        ),
     )
-    warmup_schedule = optax.polynomial_schedule(
-        init_value=0.0,
-        end_value=1.0,
-        power=1,
-        transition_steps=warmup_epochs * steps_per_epoch,
+
+
+    # training
+    model.fit(
+        x=tfds2jax_generator(ds_train),
+        validation_data=tfds2jax_generator(ds_valid),
+        epochs=FLAGS.epochs,
+        verbose=2,
+        steps_per_epoch=N_BATCHES_TRAIN,
+        validation_steps=N_BATCHES_VALID,
+        callbacks=[
+            elegy.callbacks.ModelCheckpoint(FLAGS.output_dir, save_best_only=True),
+            elegy.callbacks.TerminateOnNaN(),
+            elegy.callbacks.TensorBoard(logdir=FLAGS.output_dir),
+        ],
     )
-    schedule = lambda x: jnp.minimum(cosine_schedule(x), warmup_schedule(x))
-    optimizer = optax.sgd(lr, momentum, nesterov=NESTEROV)
-    optimizer = optax.chain(optimizer, optax.scale_by_schedule(schedule))
-    return optimizer
 
 
-module = getattr(elegy.nets.resnet, MODEL)(dtype=DTYPE)
-model = elegy.Model(
-    module,
-    loss=[
-        elegy.losses.SparseCategoricalCrossentropy(from_logits=True, weight=LOSS_SCALE),
-        elegy.regularizers.GlobalL2(L2_REGULARIZATION / 2 * LOSS_SCALE),
-    ],
-    metrics=elegy.metrics.SparseCategoricalAccuracy(),
-    optimizer=build_optimizer(
-        LEARNING_RATE / LOSS_SCALE, MOMENTUM, N_BATCHES_TRAIN, EPOCHS
-    ),
-)
 
-
-# training
-model.fit(
-    x=tfds2jax_generator(ds_train),
-    validation_data=tfds2jax_generator(ds_valid),
-    epochs=EPOCHS,
-    verbose=2,
-    steps_per_epoch=N_BATCHES_TRAIN,
-    validation_steps=N_BATCHES_VALID,
-    callbacks=[
-        elegy.callbacks.ModelCheckpoint(OUTPUT_DIRECTORY, save_best_only=True),
-        elegy.callbacks.TerminateOnNaN(),
-        elegy.callbacks.TensorBoard(logdir=OUTPUT_DIRECTORY),
-    ],
-)
+if __name__=='__main__':
+    app.run(main)

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -35,13 +35,6 @@ def main(debug: bool = False, eager: bool = False, logdir: str = "runs"):
     print("X_test:", X_test.shape, X_test.dtype)
     print("y_test:", y_test.shape, y_test.dtype)
 
-    class Lambda(elegy.Module):
-        def __init__(self, f):
-            super().__init__()
-            self.f = f
-
-        def call(self, x):
-            return self.f(x)
 
     class MLP(elegy.Module):
         """Standard LeNet-300-100 MLP network."""

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -35,7 +35,6 @@ def main(debug: bool = False, eager: bool = False, logdir: str = "runs"):
     print("X_test:", X_test.shape, X_test.dtype)
     print("y_test:", y_test.shape, y_test.dtype)
 
-
     class MLP(elegy.Module):
         """Standard LeNet-300-100 MLP network."""
 

--- a/examples/mnist_conv.py
+++ b/examples/mnist_conv.py
@@ -57,11 +57,11 @@ def main(debug: bool = False, eager: bool = False, logdir: str = "runs"):
             x = ConvBlock()(x, 64, [3, 3], stride=2)
             x = ConvBlock()(x, 128, [3, 3], stride=2)
 
-            # 1x1 Conv
-            x = elegy.nn.Linear(10)(x)
-
             # GlobalAveragePooling2D
             x = jnp.mean(x, axis=[1, 2])
+
+            # 1x1 Conv
+            x = elegy.nn.Linear(10)(x)
 
             return x
 


### PR DESCRIPTION
- refactored `examples/imagenet/resnet_imagenet.py` to accept parameters instead of modifying them inside the script
- added `README.md` for `examples/imagenet/`
- removed unnecessary `Lambda` class from `examples/mnist.py`
- moved global average pooling in `examples/mnist_conv.py` before the `Linear` layer