### PR TITLE
Better save + load

### DIFF
--- a/elegy/model/model.py
+++ b/elegy/model/model.py
@@ -773,6 +773,7 @@ class Model(ModelBase):
 
         Arguments:
             path: path to a saved model's directory.
+            include_optimizer: If True, loads optimizer's state if available.
         """
         if isinstance(path, str):
             path = Path(path)
@@ -810,6 +811,7 @@ def load(path: tp.Union[str, Path], include_optimizer: bool = True) -> Model:
 
     Arguments:
         path: path to a saved model's directory.
+        include_optimizer: If True, loads optimizer's state if available.
 
     Raises:
         OSError: in case the model was not found or could not be


### PR DESCRIPTION
Reinserts saving the model separate from the weights to improve portability. If `elegy.model.load` gives you an error due to the `model.pkl` you can still try to construct the model yourself using its source code and then use `Model.load` to load its weights which are saved as `.h5`.

Caveats:
* The optimizer state is still saved as a separate file using `pickle` due to `deepdish` handing of `NamedTuple`s as regular tuples. If you get an error when loading the optimizer you can set `include_optimizer=False` on the `load` functions.