### PR TITLE
float sample_weight for precision/recall metrics

### DIFF
--- a/elegy/metrics/precision_test.py
+++ b/elegy/metrics/precision_test.py
@@ -50,6 +50,15 @@ class PrecisionTest(TestCase):
             ),
         )
 
+
+        float_sample_weight = np.random.uniform(0, 1, size=(6, 7))[np.newaxis]
+        assert np.allclose(
+            tfk.metrics.Precision(thresholds=0.3)(
+                y_true, y_pred, sample_weight=float_sample_weight
+            ),
+            elegy.metrics.Precision(threshold=0.3)(y_true,  y_pred, sample_weight=float_sample_weight, ),
+        )
+
     #
     def test_cummulative(self):
         tm = tfk.metrics.Precision(thresholds=0.3)

--- a/elegy/metrics/precision_test.py
+++ b/elegy/metrics/precision_test.py
@@ -50,13 +50,16 @@ class PrecisionTest(TestCase):
             ),
         )
 
-
         float_sample_weight = np.random.uniform(0, 1, size=(6, 7))[np.newaxis]
         assert np.allclose(
             tfk.metrics.Precision(thresholds=0.3)(
                 y_true, y_pred, sample_weight=float_sample_weight
             ),
-            elegy.metrics.Precision(threshold=0.3)(y_true,  y_pred, sample_weight=float_sample_weight, ),
+            elegy.metrics.Precision(threshold=0.3)(
+                y_true,
+                y_pred,
+                sample_weight=float_sample_weight,
+            ),
         )
 
     #

--- a/elegy/metrics/recall_test.py
+++ b/elegy/metrics/recall_test.py
@@ -39,6 +39,14 @@ class RecallTest(TestCase):
             ),
         )
 
+        float_sample_weight = np.random.uniform(0, 1, size=(6, 7))[np.newaxis]
+        assert np.allclose(
+            tfk.metrics.Recall(thresholds=0.3)(y_true, y_pred, sample_weight=float_sample_weight),
+            elegy.metrics.Recall(threshold=0.3)(y_true, y_pred, sample_weight=float_sample_weight)
+        )
+
+
+
     def test_cummulative(self):
         tm = tfk.metrics.Recall(thresholds=0.3)
         em = elegy.metrics.Recall(threshold=0.3)

--- a/elegy/metrics/recall_test.py
+++ b/elegy/metrics/recall_test.py
@@ -41,11 +41,13 @@ class RecallTest(TestCase):
 
         float_sample_weight = np.random.uniform(0, 1, size=(6, 7))[np.newaxis]
         assert np.allclose(
-            tfk.metrics.Recall(thresholds=0.3)(y_true, y_pred, sample_weight=float_sample_weight),
-            elegy.metrics.Recall(threshold=0.3)(y_true, y_pred, sample_weight=float_sample_weight)
+            tfk.metrics.Recall(thresholds=0.3)(
+                y_true, y_pred, sample_weight=float_sample_weight
+            ),
+            elegy.metrics.Recall(threshold=0.3)(
+                y_true, y_pred, sample_weight=float_sample_weight
+            ),
         )
-
-
 
     def test_cummulative(self):
         tm = tfk.metrics.Recall(thresholds=0.3)

--- a/elegy/metrics/reduce_confusion_matrix.py
+++ b/elegy/metrics/reduce_confusion_matrix.py
@@ -39,32 +39,32 @@ def reduce(
             raise e
 
     if reduction == Reduction.TRUE_POSITIVES:
-        if sample_weight is not None:
-            y_true = y_true * sample_weight
-            y_pred = y_pred * sample_weight
         mask = y_pred == 1
-        value = jnp.sum(y_true[mask] == 1)
+        hits = y_true == y_pred
+        if sample_weight is not None:
+            hits = hits * sample_weight
+        value = jnp.sum(hits * mask)
 
     if reduction == Reduction.FALSE_POSITIVES:
-        if sample_weight is not None:
-            y_true = y_true * sample_weight
-            y_pred = y_pred * sample_weight
         mask = y_pred == 1
-        value = jnp.sum(y_true[mask] == 0)
+        misses = y_true != y_pred
+        if sample_weight is not None:
+            misses = misses * sample_weight
+        value = jnp.sum(misses * mask)
 
     if reduction == Reduction.FALSE_NEGATIVES:
-        if sample_weight is not None:
-            y_true = y_true * sample_weight
-            y_pred = y_pred * sample_weight
         mask = y_true == 1
-        value = jnp.sum(y_pred[mask] == 0)
+        misses = y_true != y_pred
+        if sample_weight is not None:
+            misses = misses * sample_weight
+        value = jnp.sum(misses * mask)
 
     if reduction == Reduction.TRUE_NEGATIVES:
-        if sample_weight is not None:
-            y_true = y_true * sample_weight
-            y_pred = y_pred * sample_weight
         mask = y_true == 0
-        value = jnp.sum(y_pred[mask] == 0)
+        hits = y_true == y_pred
+        if sample_weight is not None:
+            hits = hits * sample_weight
+        value = jnp.sum(hits * mask)
 
     cm_metric += value
     return cm_metric


### PR DESCRIPTION
`Precision` and `Recall` metrics now accept floating point `sample_weight` parameters