### PR TITLE
`sparse_categorical_crossentropy` should check bounds

### DIFF
--- a/docs/api/losses/mean_absolute_percentage_error.md
+++ b/docs/api/losses/mean_absolute_percentage_error.md
@@ -1,5 +1,6 @@
 
 # elegy.losses.mean_absolute_percentage_error
+
 ::: elegy.losses.mean_absolute_percentage_error.mean_absolute_percentage_error
     selection:
         inherited_members: true

--- a/docs/api/metrics/F1.md
+++ b/docs/api/metrics/F1.md
@@ -1,0 +1,10 @@
+
+# elegy.metrics.F1
+
+::: elegy.metrics.f1.F1
+    selection:
+        inherited_members: true
+        members:
+            - __init__
+            - call
+        

--- a/docs/api/metrics/f1.md
+++ b/docs/api/metrics/f1.md
@@ -1,0 +1,6 @@
+
+# elegy.metrics.f1
+
+::: elegy.metrics.f1.f1
+    selection:
+        inherited_members: true

--- a/elegy/losses/__init__.py
+++ b/elegy/losses/__init__.py
@@ -28,7 +28,7 @@ __all__ = [
     "MeanAbsoluteError",
     "mean_absolute_error",
     "MeanAbsolutePercentageError",
-    "mean_percentage_absolute_error",
+    "mean_absolute_percentage_error",
     "MeanSquaredError",
     "mean_squared_error",
     "MeanSquaredLogarithmicError",

--- a/elegy/losses/sparse_categorical_crossentropy_test.py
+++ b/elegy/losses/sparse_categorical_crossentropy_test.py
@@ -32,3 +32,18 @@ def test_basic():
     )
     result = scce(y_true, y_pred)  # [0.0513, 2.303]
     assert jnp.all(jnp.isclose(result, [0.0513, 2.303], rtol=0.01))
+
+
+def test_scce_out_of_bounds():
+    ypred = jnp.zeros([4, 10])
+    ytrue0 = jnp.array([0, 0, -1, 0])
+    ytrue1 = jnp.array([0, 0, 10, 0])
+
+    scce = elegy.losses.SparseCategoricalCrossentropy()
+
+    assert jnp.isnan(scce(ytrue0, ypred)).any()
+    assert jnp.isnan(scce(ytrue1, ypred)).any()
+
+    scce = elegy.losses.SparseCategoricalCrossentropy(check_bounds=False)
+    assert not jnp.isnan(scce(ytrue0, ypred)).any()
+    assert not jnp.isnan(scce(ytrue1, ypred)).any()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,7 @@ nav:
       binary_crossentropy: api/losses/binary_crossentropy.md
       cosine_similarity: api/losses/cosine_similarity.md
       mean_absolute_error: api/losses/mean_absolute_error.md
-      mean_percentage_absolute_error: api/losses/mean_percentage_absolute_error.md
+      mean_absolute_percentage_error: api/losses/mean_absolute_percentage_error.md
       mean_squared_error: api/losses/mean_squared_error.md
       mean_squared_logarithmic_error: api/losses/mean_squared_logarithmic_error.md
       sparse_categorical_crossentropy: api/losses/sparse_categorical_crossentropy.md
@@ -75,6 +75,7 @@ nav:
       BinaryAccuracy: api/metrics/BinaryAccuracy.md
       BinaryCrossentropy: api/metrics/BinaryCrossentropy.md
       CategoricalAccuracy: api/metrics/CategoricalAccuracy.md
+      F1: api/metrics/F1.md
       Mean: api/metrics/Mean.md
       MeanAbsoluteError: api/metrics/MeanAbsoluteError.md
       MeanSquaredError: api/metrics/MeanSquaredError.md
@@ -88,6 +89,7 @@ nav:
       binary_accuracy: api/metrics/binary_accuracy.md
       binary_crossentropy: api/metrics/binary_crossentropy.md
       categorical_accuracy: api/metrics/categorical_accuracy.md
+      f1: api/metrics/f1.md
       mean_absolute_error: api/metrics/mean_absolute_error.md
       mean_squared_error: api/metrics/mean_squared_error.md
       precision: api/metrics/precision.md


### PR DESCRIPTION
`jax.take_along_axis` does not throw an exception when the indices are out of bounds. This can lead to incorrect values in `sparse_categorical_crossentropy` without a warning or error. I have added the `check_bounds` (default: `True`) parameter which sets the loss to `NaN` when there are invalid values in `y_true`.