### PR TITLE
SCCE fix for bug in Jax<0.2.7

### DIFF
--- a/elegy/losses/sparse_categorical_crossentropy.py
+++ b/elegy/losses/sparse_categorical_crossentropy.py
@@ -17,9 +17,6 @@ def sparse_categorical_crossentropy(
 ) -> jnp.ndarray:
 
     n_classes = y_pred.shape[-1]
-    # fix for a bug in jax<0.2.7 where take_along_axis returns wrong values
-    if y_true.dtype in [jnp.int8, jnp.uint8, jnp.int16, jnp.uint16]:
-        y_true = y_true.astype(jnp.int32)
 
     if from_logits:
         y_pred = jax.nn.log_softmax(y_pred)

--- a/elegy/losses/sparse_categorical_crossentropy.py
+++ b/elegy/losses/sparse_categorical_crossentropy.py
@@ -17,7 +17,7 @@ def sparse_categorical_crossentropy(
 ) -> jnp.ndarray:
 
     n_classes = y_pred.shape[-1]
-    #fix for a bug in jax<0.2.7 where take_along_axis returns wrong values
+    # fix for a bug in jax<0.2.7 where take_along_axis returns wrong values
     if y_true.dtype in [jnp.int8, jnp.uint8, jnp.int16, jnp.uint16]:
         y_true = y_true.astype(jnp.int32)
 

--- a/elegy/losses/sparse_categorical_crossentropy.py
+++ b/elegy/losses/sparse_categorical_crossentropy.py
@@ -17,6 +17,9 @@ def sparse_categorical_crossentropy(
 ) -> jnp.ndarray:
 
     n_classes = y_pred.shape[-1]
+    #fix for a bug in jax<0.2.7 where take_along_axis returns wrong values
+    if y_true.dtype in [jnp.int8, jnp.uint8, jnp.int16, jnp.uint16]:
+        y_true = y_true.astype(jnp.int32)
 
     if from_logits:
         y_pred = jax.nn.log_softmax(y_pred)

--- a/elegy/losses/sparse_categorical_crossentropy_test.py
+++ b/elegy/losses/sparse_categorical_crossentropy_test.py
@@ -1,7 +1,9 @@
 import elegy
 
 
-import jax.numpy as jnp
+import jax, jax.numpy as jnp
+import numpy as np
+import tensorflow.keras as keras
 
 
 #
@@ -47,3 +49,13 @@ def test_scce_out_of_bounds():
     scce = elegy.losses.SparseCategoricalCrossentropy(check_bounds=False)
     assert not jnp.isnan(scce(ytrue0, ypred)).any()
     assert not jnp.isnan(scce(ytrue1, ypred)).any()
+
+
+def test_scce_uint8_ytrue():
+    ypred = np.random.random([2, 256, 256, 10])
+    ytrue = np.random.randint(0, 10, size=(2, 256, 256)).astype(np.uint8)
+
+    loss0 = elegy.losses.sparse_categorical_crossentropy(ytrue, ypred, from_logits=True)
+    loss1 = keras.losses.sparse_categorical_crossentropy(ytrue, ypred, from_logits=True)
+
+    assert np.allclose(loss0, loss1)

--- a/poetry.lock
+++ b/poetry.lock
@@ -350,6 +350,14 @@ optional = false
 python-versions = ">=2.7"
 
 [[package]]
+name = "flatbuffers"
+version = "1.12"
+description = "The FlatBuffers serialization format for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "future"
 version = "0.18.2"
 description = "Clean single-source support for Python 3 and 2"
@@ -614,7 +622,7 @@ test = ["pytest (>=3.6.0)", "pytest-cov", "mock"]
 
 [[package]]
 name = "jax"
-version = "0.2.5"
+version = "0.2.7"
 description = "Differentiate, compile, and transform Numpy code."
 category = "main"
 optional = false
@@ -627,7 +635,7 @@ opt_einsum = "*"
 
 [[package]]
 name = "jaxlib"
-version = "0.1.56"
+version = "0.1.57"
 description = "XLA library for JAX"
 category = "main"
 optional = false
@@ -635,6 +643,7 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 absl-py = "*"
+flatbuffers = "*"
 numpy = ">=1.12"
 scipy = "*"
 
@@ -2194,6 +2203,10 @@ entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
     {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
 ]
+flatbuffers = [
+    {file = "flatbuffers-1.12-py2.py3-none-any.whl", hash = "sha256:9e9ef47fa92625c4721036e7c4124182668dc6021d9e7c73704edd395648deb9"},
+    {file = "flatbuffers-1.12.tar.gz", hash = "sha256:63bb9a722d5e373701913e226135b28a6f6ac200d5cc7b4d919fa38d73b44610"},
+]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
@@ -2352,15 +2365,17 @@ ipywidgets = [
     {file = "ipywidgets-7.5.1.tar.gz", hash = "sha256:e945f6e02854a74994c596d9db83444a1850c01648f1574adf144fbbabe05c97"},
 ]
 jax = [
-    {file = "jax-0.2.5.tar.gz", hash = "sha256:383e0793196f73031131c334eea4a9d0d347a9cdd00fe0e97327957afbb99fce"},
+    {file = "jax-0.2.7.tar.gz", hash = "sha256:51f55ddab1518a52f43131dabb8f5ffc3e68b5f536b945e8cb8fca7c0d3d4b23"},
 ]
 jaxlib = [
-    {file = "jaxlib-0.1.56-cp36-none-macosx_10_9_x86_64.whl", hash = "sha256:391b0060c5ee526e483d239247a53641cc84a62e0e14df7448b668b3d51b68e7"},
-    {file = "jaxlib-0.1.56-cp36-none-manylinux2010_x86_64.whl", hash = "sha256:ba1b2784c522bac0dee28438b721b42ae3807f107c9ce716e403005b2823736f"},
-    {file = "jaxlib-0.1.56-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:0eb47c0695ea50cca50ef8b59b4d4ef1e9414db4f6418b24756eae87b4bbfe33"},
-    {file = "jaxlib-0.1.56-cp37-none-manylinux2010_x86_64.whl", hash = "sha256:c796a4b62ec0b91936046b4516b39cdc2bbf6a1462584da065482b0956c0bc55"},
-    {file = "jaxlib-0.1.56-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:656a19605be6ac849e35b7c3768066b0cfc0788a6f3143ab4999428f6651babc"},
-    {file = "jaxlib-0.1.56-cp38-none-manylinux2010_x86_64.whl", hash = "sha256:39202016b1cf93ac4df75c11bc89b720f450ad34b3c313f92ebb14315891fc29"},
+    {file = "jaxlib-0.1.57-cp36-none-macosx_10_9_x86_64.whl", hash = "sha256:47d4bf94f38ab9a437a69c19be6a3e1d235811d6da70922a3ff6502c33361504"},
+    {file = "jaxlib-0.1.57-cp36-none-manylinux2010_x86_64.whl", hash = "sha256:669427a85df109995cf2689945c995fd36abce80d7dbc0ad1833fa9966fa935e"},
+    {file = "jaxlib-0.1.57-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:048596b2ba458b01eb0c5680936df851f2083f6135ec9cd984f2f5ea45ad619d"},
+    {file = "jaxlib-0.1.57-cp37-none-manylinux2010_x86_64.whl", hash = "sha256:2bc945849553dbc31eba737ca81546fb47ec1e7c3340872d9b7dd329006f51a7"},
+    {file = "jaxlib-0.1.57-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:0fd3a836ec91d96a2944b5fa610780c46166c9c501629446921bd406bc83fcd0"},
+    {file = "jaxlib-0.1.57-cp38-none-manylinux2010_x86_64.whl", hash = "sha256:252e2b0043dc655e889da4363af9bc22c22d4c9728b9b2b685eac763d3a4de30"},
+    {file = "jaxlib-0.1.57-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:4e449261a7a4b08525b88dda49636eae55b9c2be464f4683dd4fd25e96134dce"},
+    {file = "jaxlib-0.1.57-cp39-none-manylinux2010_x86_64.whl", hash = "sha256:2c07605172118ab3a5a62d639a62059e4c8d67cc44de655af6606c50afa1d8c9"},
 ]
 jedi = [
     {file = "jedi-0.17.2-py2.py3-none-any.whl", hash = "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"},
@@ -2845,6 +2860,8 @@ pyyaml = [
     {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
     {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
     {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win32.whl", hash = "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e"},
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 pyzmq = [
@@ -2990,6 +3007,8 @@ tables = [
     {file = "tables-3.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:eed1e030bb077476d585697e37f2b8e37db4157ff93b485b43f374254cff8698"},
     {file = "tables-3.6.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:7acbf0e2fb7132a40f441ebb53b53c97cee05fb88ce743afdd97c681d1d377d7"},
     {file = "tables-3.6.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:94d7ccac04277089e3bb466bf5c8f7038dd53bb8f19ea9679b7fea62c5c3ae8f"},
+    {file = "tables-3.6.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:da9e1ee83c01ed4d1382c7b186d77b4c0ef80b340a48d11a66346e30342c5929"},
+    {file = "tables-3.6.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:dedb959c00ac9e84562a69e80fa858d7aa06d91f96c6cb8cccbbbaf7a879436b"},
     {file = "tables-3.6.1.tar.gz", hash = "sha256:49a972b8a7c27a8a173aeb05f67acb45fe608b64cd8e9fa667c0962a60b71b49"},
 ]
 tabulate = [
@@ -3086,19 +3105,28 @@ typed-ast = [
     {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
     {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
     {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d"},
     {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
     {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
     {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d"},
+    {file = "typed_ast-1.4.1-cp39-cp39-win32.whl", hash = "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395"},
+    {file = "typed_ast-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c"},
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
 ]
 typeguard = [


### PR DESCRIPTION
Small fix for a bug in Jax<0.2.7 where `jax.lax.take_along_axis` gives incorrect results for `uint8` indices. Very relevant for semantic segmentation.

Alternatively consider updating Jax