### PR TITLE
Better error message on elegy.States attribute access miss

### DIFF
--- a/elegy/types.py
+++ b/elegy/types.py
@@ -209,7 +209,12 @@ class States(tp.Mapping):
         return iter(self.__dict__)
 
     def __getattr__(self, key):
-        return object.__getattr__(self, key)
+        try:
+            return object.__getattr__(self, key)
+        except AttributeError:
+            raise AttributeError(
+                f"'{self.__class__.__name__}' has not attribute '{key}'"
+            )
 
     def __setattr__(self, key, value):
         raise AttributeError("can't set attribute")


### PR DESCRIPTION
Better error message when trying to access an non-existing `States` attribute (e.g. `states.banana`).
Previously it was `AttributeError: type object 'object' has no attribute '__getattr__'`