### PR TITLE
[WIP] Module Slicing 2

### DIFF
--- a/elegy/hooks.py
+++ b/elegy/hooks.py
@@ -30,6 +30,7 @@ class HooksContext(types.Protocol):
     losses: tp.Optional[types.Logs]
     metrics: tp.Optional[types.Logs]
     summaries: tp.Optional[types.Summaries]
+    named_call: tp.Optional[bool]
 
 
 @dataclass
@@ -37,12 +38,14 @@ class _HooksContext(threading.local):
     losses: tp.Optional[types.Logs]
     metrics: tp.Optional[types.Logs]
     summaries: tp.Optional[types.Summaries]
+    named_call: tp.Optional[bool]
 
 
 LOCAL: HooksContext = _HooksContext(
     losses=None,
     metrics=None,
     summaries=None,
+    named_call=None,
 )
 
 
@@ -163,6 +166,9 @@ def get_summaries() -> types.Summaries:
 def summaries_active() -> bool:
     return LOCAL.summaries is not None
 
+def named_call_active() -> bool:
+    return bool(LOCAL.named_call)
+
 
 # ----------------------------------------------------------------
 # contexts
@@ -174,6 +180,7 @@ def context(
     losses: tp.Union[types.Logs, bool, None] = None,
     metrics: tp.Union[types.Logs, bool, None] = None,
     summaries: tp.Union[types.Summaries, bool, None] = None,
+    named_call: tp.Union[str, None] = None,
     set_all: bool = False,
 ) -> tp.ContextManager[None]:
 
@@ -184,6 +191,8 @@ def context(
             metrics = True
         if summaries is None:
             summaries = True
+        if named_call is None:
+            named_call = False
 
     if isinstance(losses, bool):
         losses = {} if losses else None
@@ -193,11 +202,14 @@ def context(
 
     if isinstance(summaries, bool):
         summaries = [] if summaries else None
+    
+    named_call = bool(named_call)
 
     return _context(
         losses=losses,
         metrics=metrics,
         summaries=summaries,
+        named_call=named_call,
     )
 
 
@@ -206,15 +218,18 @@ def _context(
     losses: tp.Optional[types.Logs],
     metrics: tp.Optional[types.Logs],
     summaries: tp.Optional[types.Summaries],
+    named_call: tp.Optional[str],
 ) -> tp.Iterator[None]:
 
     prev_losses = LOCAL.losses
     prev_metrics = LOCAL.metrics
     prev_summaries = LOCAL.summaries
+    prev_named_call = LOCAL.named_call
 
     LOCAL.losses = losses
     LOCAL.metrics = metrics
     LOCAL.summaries = summaries
+    LOCAL.named_call = named_call
 
     try:
         yield
@@ -222,6 +237,7 @@ def _context(
         LOCAL.losses = prev_losses
         LOCAL.metrics = prev_metrics
         LOCAL.summaries = prev_summaries
+        LOCAL.named_call = prev_named_call
 
 
 # -------------------------------------------------------------

--- a/elegy/module.py
+++ b/elegy/module.py
@@ -362,8 +362,11 @@ class Module(metaclass=ModuleMeta):
         # this marks initialization
 
         with call_context(self):
+            method_fn = self.call
+            if hooks.named_call_active():
+                method_fn = jax.named_call(method_fn, name=get_module_path(self))
 
-            outputs = self.call(*args, **kwargs)
+            outputs = method_fn(*args, **kwargs)
 
             if hooks.summaries_active():
                 path = get_module_path(self)

--- a/elegy/slicing.py
+++ b/elegy/slicing.py
@@ -1,0 +1,195 @@
+import typing as tp
+
+import numpy as np
+import jax
+import elegy
+
+
+#TODO: docs
+
+
+
+
+def slice_model(
+    model: elegy.Model,
+    start_module: tp.Union[elegy.Module, str, None],
+    end_module: tp.Union[elegy.Module, str, None, tp.List[tp.Union[elegy.Module, str, None]]],
+    sample_input: np.ndarray,
+) -> elegy.Model:
+    if isinstance(end_module, list):
+        raise NotImplemented('Multiple end modules not yet supported')   #TODO
+    
+    model.maybe_initialize(elegy.types.Mode.pred, x=sample_input)
+
+    with elegy.hooks.context(named_call=True), jax.disable_jit():
+        jaxpr = jax.make_jaxpr(model.pred_step, static_argnums=[2,3] )(sample_input, model.states, False, False)
+    
+    eq_path, input_vars, output_vars, unresolved_vars, env = analyze_jaxpr(jaxpr.jaxpr, start_module, end_module)
+    
+    n_inputs            = len(jax.tree_leaves(sample_input))
+    toplevel_input_vars = jaxpr.jaxpr.invars[:n_inputs]
+    state_vars          = jaxpr.jaxpr.invars[n_inputs:]
+    
+    #if any([ iv in toplevel_input_vars for iv in input_vars ]):       #TODO: incorrect
+    #    raise RuntimeError('Unresolved input')
+
+    states_leaves = jax.tree_leaves(model.states)
+    stateless_input_vars = [iv for iv in input_vars if not iv.intersection(state_vars)]
+    
+    return SlicedModule(model.module, eq_path, stateless_input_vars)
+
+
+class Environment(dict):
+    def __getitem__(self, var):
+        if isinstance(var, jax.core.Literal):
+            #literals are for some reason not hashable
+            return var.val
+        else:
+            return super().__getitem__(var)
+    
+    def __setitem__(self, var, value):
+        if isinstance(var, jax.core.Literal):
+            #ignore, literals are constant
+            pass
+        else:
+            super().__setitem__(var, value)
+    
+    def __contains__(self, var):
+        if isinstance(var, jax.core.Literal):
+            return True
+        else:
+            return super().__contains__(var)
+
+
+
+class EquivalentVars(set):
+    '''A set of jax.core.Var that are equivalent among different levels of jaxprs'''
+    pass
+
+
+def path_to_str(path: tp.Tuple[str]) -> str:
+    return '/'+'/'.join(path)
+
+def normalize_module_path(module_path: str) -> str:
+    if module_path is None:
+        return '/'
+    return module_path if module_path.startswith('/') else '/'+module_path
+
+def list_intersection(list0: tp.List[tp.Any], list1: tp.List[tp.Any]):
+    return [x for x in list0 if x in list1]
+
+def list_difference(list0: tp.List[tp.Any], list1: tp.List[tp.Any]):
+    return [x for x in list0 if x not in list1]
+
+def list_union(list0: tp.List[tp.Any], list1: tp.List[tp.Any]):
+    return list0 + list_difference(list1, list0)
+
+def update_env(env: tp.Dict[jax.core.Var, EquivalentVars], eq: jax.core.JaxprEqn):   #TODO: make immutable
+    for v in eq.invars + eq.outvars:
+        if v not in env:
+            env[v] = EquivalentVars([v])
+
+def analyze_jaxpr(jaxpr: jax.core.Jaxpr, start_path, end_path):
+    start_path = normalize_module_path(start_path)
+    end_path   = normalize_module_path(end_path)
+
+    env = Environment( [(v, EquivalentVars([v])) for v in jaxpr.invars] )
+
+    #search for end module
+    for i, eq in enumerate(jaxpr.eqns):
+        if eq.primitive.name == 'named_call':
+            modulepath = path_to_str(eq.params['name'])
+            if end_path.startswith(modulepath):
+                if end_path == modulepath:
+                    unresolved_vars = list(eq.invars)
+                    input_vars      = []
+                    output_vars     = eq.outvars
+                    eq_path         = [eq]
+                    update_env(env, eq)
+                else:
+                    inner_jaxpr = eq.params['call_jaxpr']
+                    eq_path, input_vars, output_vars, unresolved_vars, inner_env = analyze_jaxpr( inner_jaxpr, start_path, end_path )
+                    env.update(inner_env)
+                    for outer_v, inner_v in zip(eq.invars, inner_jaxpr.invars):
+                        env[outer_v].add(inner_v)
+                        inner_env[inner_v].add(outer_v)
+                    unresolved_vars = [env[v] for v in unresolved_vars]
+                    #input_vars = [env[v] for v in input_vars]
+                break
+    else:
+        #end_path not found
+        raise RuntimeError(f'End module {end_path} not found')
+    
+
+    #search from end to start, collecting only required equations
+    if len(input_vars)==0:
+        for eq in reversed(jaxpr.eqns[:i+1]):
+            common_vars = list_intersection(unresolved_vars, eq.outvars)
+            if len(common_vars):
+                unresolved_vars = list_difference(unresolved_vars, common_vars)
+                unresolved_vars = list_union(unresolved_vars, eq.invars)
+                eq_path = [eq] + eq_path
+                update_env(env, eq)
+
+            if eq.primitive.name == 'named_call':
+                modulepath = path_to_str(eq.params['name'])
+                if start_path.startswith(modulepath):
+                    if start_path == modulepath:
+                        unresolved_vars = list_difference(unresolved_vars, eq.invars)
+                        update_env(env, eq)
+                        #input_vars      = eq.invars
+                        input_vars      = [env[v] for v in eq.invars]
+                        break
+                    else:
+                        analyze_jaxpr( eq.params['call_jaxpr'], start_path, end_path )   #not quite
+                        #break
+        #else:
+            #start path not found, can happen in nested calls
+    
+    return eq_path, input_vars, output_vars, unresolved_vars, env
+
+
+
+def get_module(parentmodule:elegy.Module, name:tp.Tuple[str]):
+    if name==():
+        return parentmodule
+    else:
+        for n in name:
+            parentmodule = getattr(parentmodule, n)
+        return parentmodule
+
+
+class SlicedModule(elegy.Module):
+    def __init__(self, mainmodule:elegy.Module, equations:tp.List[jax.core.JaxprEqn], input_vars:tp.List[jax.core.Var]):
+        super().__init__()
+        self.modules = dict([ (eq.params['name'], get_module(mainmodule, eq.params['name'])) for eq in equations if eq.primitive.name=='named_call'])
+        self.equations = equations
+        self.input_vars = input_vars
+    
+    def call(self, *args):
+        if len(args)!=len(self.input_vars):
+            raise TypeError(f'Expected {len(self.input_vars)} inputs, received {len(args)}')
+
+        environment: tp.Dict[jax.core.Var, tp.Any] = Environment()
+        for equivar, arg in zip(self.input_vars, args):
+            for v in equivar:
+                environment[v] = arg
+        
+        for eq in self.equations:
+            eq_inputs = [environment[v] for v in eq.invars if v in environment]
+            if eq.primitive.name == 'named_call':
+                module = self.modules[eq.params['name']]
+                outputs = module(*eq_inputs)
+            else:
+                outputs = eq.primitive.bind(*eq_inputs, **eq.params)
+            
+            if isinstance(outputs, list):
+                outputs = tuple(outputs)
+            elif not isinstance(outputs, tuple):
+                outputs = (outputs,)
+
+            for o,v in zip(outputs, eq.outvars):
+                environment[v] = o
+        
+        return o
+

--- a/elegy/slicing_test.py
+++ b/elegy/slicing_test.py
@@ -1,0 +1,64 @@
+import jax, jax.numpy as jnp
+import elegy, elegy.slicing
+from unittest import TestCase
+
+
+
+
+
+class ModuleSlicingTest(TestCase):
+    def test_basic_slice_by_name0(self):
+        x = jnp.zeros((32, 100))
+
+        start, end = ("linear0", "linear1")
+        basicmodule = BasicModule0()
+        basicmodel  = elegy.Model(basicmodule)
+        submodule = elegy.slicing.slice_model(basicmodel, start, end, x)
+        submodel = elegy.Model(submodule)
+        basicmodule.init(rng=elegy.RNGSeq(0), set_defaults=True)(x)
+        assert submodel.predict(x).shape == (32, 10)
+        assert jnp.all(submodel.predict(x) == basicmodule.test_call0(x))
+
+    
+    def test_basic_slice_by_name1(self):
+        x = jnp.zeros((32, 100))
+
+        start, end = (None, "linear1") #None means input
+        basicmodule = BasicModule0()
+        basicmodel  = elegy.Model(basicmodule)
+        submodule = elegy.slicing.slice_model(basicmodel, start, end, x)
+        submodel = elegy.Model(submodule)
+        basicmodule.init(rng=elegy.RNGSeq(0), set_defaults=True)(x)
+        # submodel.summary(x)
+        assert submodel.predict(x).shape == (32, 10)
+        assert jnp.all(submodel.predict(x) == basicmodule.test_call1(x))
+    
+    
+
+
+
+
+
+
+class BasicModule0(elegy.Module):
+    def call(self, x):
+        x = x/255.
+        x = elegy.nn.Linear(25, name="linear0")(x)
+        x = jax.nn.relu(x)
+        x = elegy.nn.Linear(10, name="linear1")(x)
+        x = jax.nn.relu(x)
+        x = elegy.nn.Linear(5, name="linear2")(x)
+        return x
+
+    def test_call0(self, x):
+        x = self.linear0.call_with_defaults()(x)
+        x = jax.nn.relu(x)
+        x = self.linear1.call_with_defaults()(x)
+        return x
+
+    def test_call1(self, x):
+        x = x/255.
+        x = self.linear0.call_with_defaults()(x)
+        x = jax.nn.relu(x)
+        x = self.linear1.call_with_defaults()(x)
+        return x

--- a/elegy/slicing_test.py
+++ b/elegy/slicing_test.py
@@ -5,7 +5,8 @@ import elegy, elegy.slicing
 from unittest import TestCase
 
 
-
+#TODO: nested modules
+#TODO: ensure only necessary modules are executed and only once
 
 
 class BasicModuleSlicingTest(TestCase):
@@ -50,6 +51,17 @@ class BasicModuleSlicingTest(TestCase):
         assert jnp.all(ypred[1] == self.x)
         assert ypred[0].shape == (32, 10)
         assert jnp.allclose(ypred[0], self.module.test_call1(self.x))
+    
+    def test_no_path(self):
+        for start_module in ["linear2", "linear1"]:
+            try:
+                submodule = elegy.slicing.slice_model(self.model, start_module, "linear0", self.x)
+                submodel = elegy.Model(submodule)
+                submodel.summary(self.x)
+            except RuntimeError as e:
+                assert e.args[0].startswith(f"No path from {start_module} to linear0")
+            else:
+                assert False, "No error or wrong error raised"
 
 
 class ResNetSlicingTest(TestCase):
@@ -61,8 +73,8 @@ class ResNetSlicingTest(TestCase):
 
         submodule = elegy.slicing.slice_model(
             resnetmodel,
-            start_module=None,
-            end_module=[
+            start=None,
+            end=[
                 "/res_net_block_1",
                 "/res_net_block_3",
                 "/res_net_block_5",

--- a/elegy/slicing_test.py
+++ b/elegy/slicing_test.py
@@ -1,4 +1,6 @@
 import jax, jax.numpy as jnp
+import numpy as np
+
 import elegy, elegy.slicing
 from unittest import TestCase
 
@@ -7,33 +9,39 @@ from unittest import TestCase
 
 
 class ModuleSlicingTest(TestCase):
-    def test_basic_slice_by_name0(self):
-        x = jnp.zeros((32, 100))
+    def setUp(self):
+        self.x = np.random.random((32,100)).astype('float32')
+        self.module = BasicModule0()
+        self.module.init(rng=elegy.RNGSeq(0), set_defaults=True)(self.x)
+        self.model  = elegy.Model(self.module)
 
+    def test_basic_slice_by_name0(self):
         start, end = ("linear0", "linear1")
-        basicmodule = BasicModule0()
-        basicmodel  = elegy.Model(basicmodule)
-        submodule = elegy.slicing.slice_model(basicmodel, start, end, x)
+        submodule = elegy.slicing.slice_model(self.model, start, end, self.x)
         submodel = elegy.Model(submodule)
-        basicmodule.init(rng=elegy.RNGSeq(0), set_defaults=True)(x)
-        assert submodel.predict(x).shape == (32, 10)
-        assert jnp.all(submodel.predict(x) == basicmodule.test_call0(x))
+        assert submodel.predict(self.x).shape == (32, 10)
+        assert jnp.all(submodel.predict(self.x) == self.module.test_call0(self.x))
 
     
     def test_basic_slice_by_name1(self):
-        x = jnp.zeros((32, 100))
-
         start, end = (None, "linear1") #None means input
-        basicmodule = BasicModule0()
-        basicmodel  = elegy.Model(basicmodule)
-        submodule = elegy.slicing.slice_model(basicmodel, start, end, x)
+        submodule = elegy.slicing.slice_model(self.model, start, end, self.x)
         submodel = elegy.Model(submodule)
-        basicmodule.init(rng=elegy.RNGSeq(0), set_defaults=True)(x)
-        # submodel.summary(x)
-        assert submodel.predict(x).shape == (32, 10)
-        assert jnp.all(submodel.predict(x) == basicmodule.test_call1(x))
+        assert submodel.predict(self.x).shape == (32, 10)
+        assert jnp.allclose(submodel.predict(self.x), self.module.test_call1(self.x))
     
-    
+    def test_slice_multi_output(self):
+        start, end = None, ["linear1", "linear2"]
+        submodule = elegy.slicing.slice_model(self.model, start, end, self.x)
+        submodel = elegy.Model(submodule)
+        
+        outputs = submodel.predict(self.x)
+        true_outputs = self.module.test_call2(self.x)
+        assert len(outputs) == 2
+        assert outputs[0].shape == true_outputs[0].shape
+        assert outputs[1].shape == true_outputs[1].shape
+        assert jnp.allclose(outputs[0], true_outputs[0])
+        assert jnp.allclose(outputs[1], true_outputs[1])
 
 
 
@@ -62,3 +70,12 @@ class BasicModule0(elegy.Module):
         x = jax.nn.relu(x)
         x = self.linear1.call_with_defaults()(x)
         return x
+
+    def test_call2(self, x):
+        x = x/255.
+        x = self.linear0.call_with_defaults()(x)
+        x = jax.nn.relu(x)
+        x = x0 = self.linear1.call_with_defaults()(x)
+        x = jax.nn.relu(x)
+        x = x1 = self.linear2.call_with_defaults()(x)
+        return x0, x1


### PR DESCRIPTION
Alternative approach to #115 
- This is now based on `jax.make_jaxpr` and `jax.named_call`, not on summaries. Specifically, I've extended hooks context with a new attribute, if it is active, `Module.call` will be wrapped with `jax.named_call`. This allows identifying individual modules in the low-level jaxpr commands, so the interface is basically the same as before. However, one can now use arbitrary JAX functions without having to wrap them in modules:
```python
class Module(elegy.Module):
    def call(self, x):
        x = x/255.
        x = elegy.nn.Linear(300, name="linear0")(x)
        x = jax.nn.relu(x)
        x = elegy.nn.Linear(100, name="linear1")(x)
        x = jax.nn.relu(x)
        x = elegy.nn.Linear(10,  name="linear2")(x)
        return x

x         = np.random.random([32,1024])
model     = elegy.Model(Module())
submodule = elegy.slicing.slice_model(model, start='input', end=['linear0', 'linear1'], sample_input=x)
out       = elegy.Model(submodule).predict(x)

assert out[0].shape == (32,300)
assert out[1].shape == (32,100)
```
- Some limitations still apply:
  - Only Elegy Modules are possible as start and end targets
  - Only one start target allowed. This is possible to fix, but might get complex
- Internal logic is simpler, not graph-based as before
- WIP, still need to cover some edge cases and test more
