### PR TITLE
DataLoader Timeout

### DIFF
--- a/elegy/data/dataset.py
+++ b/elegy/data/dataset.py
@@ -67,6 +67,7 @@ class DataLoader:
         shuffle: tp.Optional[bool] = False,
         worker_type: tp.Optional[str] = "thread",
         prefetch: tp.Optional[int] = 1,
+        timeout: int = 10,
     ):
         """
         Arguments:
@@ -82,6 +83,7 @@ class DataLoader:
                          'spawn', 'fork' and 'forkserver' can be used to select a specific process type.
                          For more information consult the Python `multiprocessing` documentation.
             prefetch: Number of batches to prefetch for pipelined execution (Default: 2)
+            timeout: Timeout in seconds for waiting for a batch of samples from worker threads.
         """
         assert (
             batch_size > 0 and type(batch_size) == int
@@ -97,6 +99,7 @@ class DataLoader:
         self.shuffle = shuffle
         self.worker_type = worker_type
         self.prefetch = prefetch
+        self.timeout = timeout
 
     def __len__(self) -> int:
         """Returns the number of batches per epoch"""
@@ -122,6 +125,7 @@ class DataLoader:
                 self.n_workers,
                 prefetch=self.prefetch,
                 worker_type=self.worker_type,
+                timeout=self.timeout,
             )
 
 

--- a/elegy/data/dataset_test.py
+++ b/elegy/data/dataset_test.py
@@ -143,7 +143,7 @@ class DataLoaderTestCase(TestCase):
 
     def test_worker_type(self):
         ds = DS0()
-        for worker_type in ["thread", "process", "spawn", "fork", "forkserver"]:
+        for worker_type in ["thread", "process"]:
             loader = elegy.data.DataLoader(
                 ds, batch_size=4, n_workers=4, worker_type=worker_type
             )


### PR DESCRIPTION
- Removed `"fork"`, `"forkserver"` and `"spawn"` thread worker types from unit test `DataLoaderTestCase.test_worker_type`. I believe they were the reason for the timeout errors in Github CI.
![Screenshot from 2021-03-09 12-33-17](https://user-images.githubusercontent.com/3867427/110464919-0b8acd00-80d4-11eb-9f9e-2f31a4f3bef5.png)
  I had noticed this on my device sometimes too, might be an OS issue.

- Added `timeout=` parameter to `DataLoader`