### PR TITLE
Support creating Dataloader directly from HuggingFace dataset

### DIFF
--- a/elegy/data/dataset.py
+++ b/elegy/data/dataset.py
@@ -114,7 +114,7 @@ class DataLoader:
             np.random.shuffle(indices)
 
         batched_indices = [
-            indices[i:][: self.batch_size]
+            indices[i:][: self.batch_size].tolist()
             for i in range(0, len(indices), self.batch_size)
         ]
 


### PR DESCRIPTION
Currently it's not possible to create a `eg.data.DataLoader` from huggingface's `dataset`.
HF's `dataset` check the indices values of the type `int, slice, range str, Iterable`. 
```
    # Check if key is valid
    if not isinstance(key, (int, slice, range, str, Iterable)):
        _raise_bad_key_type(key)
```
Converting the indices from from  np.int64 to python's int fix this.
