### PR TITLE
Donate model's memory buffer to jit/pmap functions.

### DIFF
--- a/elegy/model/model_core.py
+++ b/elegy/model/model_core.py
@@ -124,17 +124,18 @@ class Eager(DistributedStrategy):
 
 @dataclass(unsafe_hash=True)
 class JIT(DistributedStrategy):
+    # donate 'model' memory buffer since we return an updated model
     def init_step_fn(self, model: M) -> InitStep[M]:
-        return jax.jit(model.__class__._static_init_step)
+        return jax.jit(model.__class__._static_init_step, donate_argnums=0)
 
     def pred_step_fn(self, model: M) -> PredStep[M]:
-        return jax.jit(model.__class__._static_pred_step)
+        return jax.jit(model.__class__._static_pred_step, donate_argnums=0)
 
     def test_step_fn(self, model: M) -> TestStep[M]:
-        return jax.jit(model.__class__._static_test_step)
+        return jax.jit(model.__class__._static_test_step, donate_argnums=0)
 
     def train_step_fn(self, model: M) -> TrainStep[M]:
-        return jax.jit(model.__class__._static_train_step)
+        return jax.jit(model.__class__._static_train_step, donate_argnums=0)
 
 
 @dataclass(unsafe_hash=True)
@@ -204,12 +205,14 @@ class DataParallel(DistributedStrategy):
         return jax.pmap(
             model.__class__._static_init_step,
             axis_name="device",
+            donate_argnums=0,
         )
 
     def pred_step_fn(self, model: M) -> PredStep[M]:
         return jax.pmap(
             model.__class__._static_pred_step,
             axis_name="device",
+            donate_argnums=0,
         )
 
     def test_step_fn(self, model: M) -> TestStep[M]:
@@ -217,6 +220,7 @@ class DataParallel(DistributedStrategy):
             model.__class__._static_test_step,
             axis_name="device",
             out_axes=(0, None, 0),  # None = logs not replicated
+            donate_argnums=0,
         )
 
     def train_step_fn(self, model: M) -> TrainStep[M]:
@@ -224,6 +228,7 @@ class DataParallel(DistributedStrategy):
             model.__class__._static_train_step,
             axis_name="device",
             out_axes=(None, 0),  # None = logs not replicated
+            donate_argnums=0,
         )
 
 


### PR DESCRIPTION
As discussed in [Discord](https://discord.com/channels/940300133189435404/940310930850471996/956010282830921738), using `donate_argnums=1` in Jit/pmap will reduce GPU/TPU memory by 1/3.

Before: 
![image0](https://user-images.githubusercontent.com/12573521/159612436-5c16a62f-3979-48e9-bc25-e80db95bbbfd.jpg)
 After: 
<img width="975" alt="Screen_Shot_2022-03-23_at_09 00 54" src="https://user-images.githubusercontent.com/12573521/159612563-fbbe974a-1dbe-457c-a6b2-1026b9a58dad.png">

Technically, only donate argnum in train_step_fn is necessary, since all other *_step_fn got called inside train_step_fn anyway. But for consistency I add donate argnum to every *step_fn anyway. 
